### PR TITLE
Fix schema interfaces with _id field

### DIFF
--- a/lib/db/models/address.ts
+++ b/lib/db/models/address.ts
@@ -1,6 +1,7 @@
 import mongoose, { Schema, type Document, type Model } from "mongoose"
 
 export interface IAddress extends Document {
+  _id: mongoose.Types.ObjectId
   userId: mongoose.Types.ObjectId
   country: string
   city: string

--- a/lib/db/models/booking.ts
+++ b/lib/db/models/booking.ts
@@ -79,6 +79,7 @@ export interface IBookingReview {
 }
 
 export interface IBooking extends Document {
+  _id: mongoose.Types.ObjectId
   bookingNumber: string // New: Unique 6-digit booking number
   userId?: Types.ObjectId // Made optional for guest bookings
   bookedByUserName?: string // New: Name of the user who made the booking

--- a/lib/db/models/city.ts
+++ b/lib/db/models/city.ts
@@ -1,6 +1,7 @@
 import mongoose, { Schema, type Document, type Model } from "mongoose"
 
 export interface ICity extends Document {
+  _id: mongoose.Types.ObjectId
   name: string
   isActive: boolean
   coordinates: {

--- a/lib/db/models/coupon-usage.ts
+++ b/lib/db/models/coupon-usage.ts
@@ -1,6 +1,7 @@
 import mongoose, { Schema, type Document, type Model, type Types } from "mongoose"
 
 export interface ICouponUsage extends Document {
+  _id: mongoose.Types.ObjectId
   couponId: Types.ObjectId
   userId: Types.ObjectId
   orderId: Types.ObjectId // Will be used when 'regular orders' are implemented

--- a/lib/db/models/coupon.ts
+++ b/lib/db/models/coupon.ts
@@ -1,6 +1,7 @@
 import mongoose, { Schema, type Document, type Model, type Types } from "mongoose"
 
 export interface ICoupon extends Document {
+  _id: mongoose.Types.ObjectId
   code: string
   description?: string
   discountType: "percentage" | "fixedAmount"

--- a/lib/db/models/gift-voucher-purchase.ts
+++ b/lib/db/models/gift-voucher-purchase.ts
@@ -1,6 +1,7 @@
 import mongoose, { Schema, type Document, type Model } from "mongoose"
 
 export interface IGiftVoucherPurchase extends Document {
+  _id: mongoose.Types.ObjectId
   userId: mongoose.Types.ObjectId
   status: "abandoned_pending_payment" | "completed"
   formState: {

--- a/lib/db/models/partner-coupon-batch.ts
+++ b/lib/db/models/partner-coupon-batch.ts
@@ -1,6 +1,7 @@
 import mongoose, { Schema, type Document, type Model, type Types } from "mongoose"
 
 export interface IPartnerCouponBatch extends Document {
+  _id: mongoose.Types.ObjectId
   name: string
   description?: string
   assignedPartnerId?: Types.ObjectId // Partner User ID

--- a/lib/db/models/partner-profile.ts
+++ b/lib/db/models/partner-profile.ts
@@ -1,6 +1,7 @@
 import mongoose, { Schema, Document, Model } from "mongoose"
 
 export interface IPartnerProfile extends Document {
+  _id: mongoose.Types.ObjectId
   userId: mongoose.Types.ObjectId
   businessNumber: string
   contactName: string

--- a/lib/db/models/password-reset-token.ts
+++ b/lib/db/models/password-reset-token.ts
@@ -1,9 +1,12 @@
 import mongoose, { Schema, type Document, type Model } from "mongoose"
 
 export interface IPasswordResetToken extends Document {
+  _id: mongoose.Types.ObjectId
   userId: mongoose.Schema.Types.ObjectId
   token: string
   expiresAt: Date
+  createdAt: Date
+  updatedAt: Date
 }
 
 const PasswordResetTokenSchema: Schema = new Schema(

--- a/lib/db/models/payment-method.ts
+++ b/lib/db/models/payment-method.ts
@@ -1,6 +1,7 @@
 import mongoose, { Schema, type Document } from "mongoose"
 
 export interface IPaymentMethod extends Document {
+  _id: mongoose.Types.ObjectId
   userId: string
   cardNumber: string
   expiryMonth: string

--- a/lib/db/models/review.ts
+++ b/lib/db/models/review.ts
@@ -1,6 +1,7 @@
 import mongoose, { Schema, type Document, type Model, type Types } from "mongoose"
 
 export interface IReview extends Document {
+  _id: mongoose.Types.ObjectId
   bookingId: Types.ObjectId
   userId: Types.ObjectId // מי שמילא את חוות הדעת
   professionalId: Types.ObjectId // המטפל שעליו חוות הדעת

--- a/lib/db/models/subscription-purchase.ts
+++ b/lib/db/models/subscription-purchase.ts
@@ -1,6 +1,7 @@
 import mongoose, { Schema, type Document, type Model } from "mongoose"
 
 export interface ISubscriptionPurchase extends Document {
+  _id: mongoose.Types.ObjectId
   userId: mongoose.Types.ObjectId
   status: "abandoned_pending_payment" | "completed"
   formState: {

--- a/lib/db/models/subscription.ts
+++ b/lib/db/models/subscription.ts
@@ -1,6 +1,7 @@
 import mongoose, { Schema, type Document } from "mongoose"
 
 export interface ISubscription extends Document {
+  _id: mongoose.Types.ObjectId
   name: string
   description: string
   quantity: number

--- a/lib/db/models/treatment.ts
+++ b/lib/db/models/treatment.ts
@@ -10,6 +10,7 @@ export interface ITreatmentDuration extends Document {
 }
 
 export interface ITreatment extends Document {
+  _id: mongoose.Types.ObjectId
   name: string
   category: "massages" | "facial_treatments"
   description?: string

--- a/lib/db/models/user-subscription.ts
+++ b/lib/db/models/user-subscription.ts
@@ -1,6 +1,7 @@
 import mongoose, { Schema, type Document, type Model } from "mongoose"
 
 export interface IUserSubscription extends Document {
+  _id: mongoose.Types.ObjectId
   code: string // Unique redemption code for the subscription
   userId?: mongoose.Types.ObjectId // Made optional for guest purchases
   subscriptionId: mongoose.Types.ObjectId // Ref to Subscription model

--- a/lib/db/models/verification-token.ts
+++ b/lib/db/models/verification-token.ts
@@ -1,38 +1,33 @@
-import mongoose from "mongoose"
+import mongoose, { Schema, type Document, type Model } from "mongoose"
 
-const verificationTokenSchema = new mongoose.Schema({
-  identifier: {
-    type: String,
-    required: true,
+export interface IVerificationToken extends Document {
+  _id: mongoose.Types.ObjectId
+  identifier: string
+  identifierType: "email" | "phone"
+  code: string
+  attempts: number
+  expiresAt: Date
+  createdAt: Date
+  updatedAt: Date
+}
+
+const VerificationTokenSchema = new Schema<IVerificationToken>(
+  {
+    identifier: { type: String, required: true },
+    identifierType: { type: String, enum: ["email", "phone"], required: true },
+    code: { type: String, required: true },
+    attempts: { type: Number, default: 0 },
+    expiresAt: { type: Date, required: true },
   },
-  identifierType: {
-    type: String,
-    enum: ["email", "phone"],
-    required: true,
-  },
-  code: {
-    type: String,
-    required: true,
-  },
-  attempts: {
-    type: Number,
-    default: 0,
-  },
-  expiresAt: {
-    type: Date,
-    required: true,
-  },
-  createdAt: {
-    type: Date,
-    default: Date.now,
-  },
-})
+  { timestamps: true },
+)
 
 // Create indexes for faster queries
-verificationTokenSchema.index({ identifier: 1, identifierType: 1, code: 1 })
-verificationTokenSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 })
-verificationTokenSchema.index({ identifier: 1, identifierType: 1, expiresAt: 1 })
+VerificationTokenSchema.index({ identifier: 1, identifierType: 1, code: 1 })
+VerificationTokenSchema.index({ expiresAt: 1 }, { expireAfterSeconds: 0 })
+VerificationTokenSchema.index({ identifier: 1, identifierType: 1, expiresAt: 1 })
 
-const VerificationToken = mongoose.models.VerificationToken || mongoose.model("VerificationToken", verificationTokenSchema)
+const VerificationToken: Model<IVerificationToken> =
+  mongoose.models.VerificationToken || mongoose.model<IVerificationToken>("VerificationToken", VerificationTokenSchema)
 
 export default VerificationToken

--- a/lib/db/models/working-hours.ts
+++ b/lib/db/models/working-hours.ts
@@ -73,6 +73,7 @@ export interface ISpecialDate {
 }
 
 export interface IWorkingHoursSettings extends Document {
+  _id: mongoose.Types.ObjectId
   fixedHours: IFixedHours[]
   specialDates: ISpecialDate[] // Legacy field - will be migrated to specialDateEvents
   specialDateEvents?: ISpecialDateEvent[] // New field for grouped events


### PR DESCRIPTION
## Summary
- add missing `_id` fields across model interfaces
- define interface and schema for verification tokens

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: module errors)*
- `npm run lint` *(fails: many lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6859d374da6c832b98c332236321b614