### PR TITLE
Fix gift voucher treatments fetch

### DIFF
--- a/actions/payment-method-actions.ts
+++ b/actions/payment-method-actions.ts
@@ -191,7 +191,7 @@ export async function getActivePaymentMethods() {
     // Serialize the payment methods to plain objects and mask card numbers
     const serializedPaymentMethods = paymentMethods.map((pm) => ({
       ...pm,
-      id: pm.id.toString(),
+      id: pm._id.toString(),
       cardNumber: `****-****-****-${pm.cardNumber.slice(-4)}`, // Mask card number for security
     }))
 

--- a/actions/subscription-actions.ts
+++ b/actions/subscription-actions.ts
@@ -27,7 +27,7 @@ export async function getSubscriptions(): Promise<{
 
     const serializedSubscriptions = subscriptions.map((sub) => ({
       ...sub,
-      _id: sub.id.toString(),
+      _id: sub._id.toString(),
       treatmentId: sub.treatmentId ? {
         ...sub.treatmentId,
         _id: sub.treatmentId._id.toString(),

--- a/app/(orders)/purchase/gift-voucher/actions.ts
+++ b/app/(orders)/purchase/gift-voucher/actions.ts
@@ -47,7 +47,7 @@ export async function getTreatmentsForSelection(): Promise<GetTreatmentsResult> 
     return {
       success: true,
       treatments: treatments.map((treatment: ITreatment) => ({
-        _id: treatment.id.toString(),
+        _id: treatment._id.toString(),
         name: treatment.name,
         description: treatment.description || "",
         category: treatment.category,


### PR DESCRIPTION
## Summary
- correct id field usage in the gift voucher purchase actions
- fix ID serialization in subscription and payment methods actions

## Testing
- `npm run lint --silent` *(fails: many pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685dd4bb024083238d6b42452df3b46b