### PR TITLE
Fix negative commission validation

### DIFF
--- a/lib/db/models/booking.ts
+++ b/lib/db/models/booking.ts
@@ -196,7 +196,8 @@ const PriceDetailsSchema = new Schema<IPriceDetails>(
     appliedGiftVoucherId: { type: Schema.Types.ObjectId, ref: "GiftVoucher" },
     redeemedUserSubscriptionId: { type: Schema.Types.ObjectId, ref: "UserSubscription" },
     totalProfessionalPayment: { type: Number, min: 0 },
-    totalOfficeCommission: { type: Number, min: 0 },
+    // Office commission might be negative when the company pays out of pocket
+    totalOfficeCommission: { type: Number },
     baseProfessionalPayment: { type: Number, min: 0 },
     surchargesProfessionalPayment: { type: Number, min: 0 },
   },


### PR DESCRIPTION
## Summary
- allow negative values for booking office commission in schema

## Testing
- `npm run lint` *(fails: many unrelated lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685dde0bb318832396ef9c7b9a7adfa3