### PR TITLE
Fix path traversal in wiki

### DIFF
--- a/app/wiki/[...slug]/page.tsx
+++ b/app/wiki/[...slug]/page.tsx
@@ -14,6 +14,11 @@ export default async function WikiPage({ params }: { params: Params }) {
   const slug = params.slug ?? []
   const docsDir = path.join(process.cwd(), 'user-docs')
   const targetPath = path.join(docsDir, ...slug)
+  const relative = path.relative(docsDir, targetPath)
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    console.warn('Invalid wiki path traversal attempt:', slug.join('/'))
+    notFound()
+  }
 
   try {
     const stat = await fs.stat(targetPath)


### PR DESCRIPTION
## Summary
- sanitize wiki slug paths to prevent directory traversal

## Testing
- `npm run lint` *(fails: no-unused-vars, react-hooks/exhaustive-deps, etc.)*
- `npm run type-check` *(fails: TS2304 Cannot find name 'bookingDetailsLink', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_686974f965a8832b9b985b3bcbd0a776